### PR TITLE
2021.01.16 Release

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -59,7 +59,7 @@ jobs:
                   pip install -r requirements.txt
                   pytest --cov=./ --cov-report=xml
             - name: Upload coverage to Codecov
-              uses: codecov/codecov-action@v1.1.0
+              uses: codecov/codecov-action@v1.2.1
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
                   file: ./coverage.xml

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,7 +23,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: [3.6, 3.7, 3.8, 3.9]
+                python-version: [3.7, 3.8, 3.9]
         steps:
             - uses: actions/checkout@v2
             - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ CHANGELOG
 - xlrd 1.20 to 2.0.1
 
 ## motherstarter excel functionality
-- Migrated motherstarter input/output xlsx functions from `xlrd` to `colorama`
+- Migrated motherstarter input/output xlsx functions from `xlrd` to `openpyxl`
 
 # 2020.11.16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 CHANGELOG
 =======
 
+# 2020.12.23
+
+## Version bumps
+- bandit 1.6.2 to bandit 1.7.0
+- pandas 1.1.4 to 1.1.5
+- pytest 6.1.2 to 6.2.1
+- xlrd 1.20 to 2.0.1
+
+## motherstarter excel functionality
+- Migrated motherstarter input/output xlsx functions from `xlrd` to `colorama`
+
 # 2020.11.16
 
 - Uplifted documentation, including overview diagram, advanced usage and links to how-to videos.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 CHANGELOG
 =======
 
+# 2021.01.16
+
+## BREAKING CHANGES - Python 3.6 Support Depcrecated
+
+- Due to an inherit [`pandas` dependency, python 3.6 support has been deprecated](https://pandas.pydata.org/pandas-docs/stable/whatsnew/v1.2.0.html#increased-minimum-version-for-python).
+
+## Version bumps
+
+- pandas 1.1.5 to 1.2.0
+- nox 2020.8.22 to 2020.12.31
+
+## Test Coverage Optimisations
+
+- Ignore `codecov` analysis on motherstarter `setup.py` and `noxfile.py` files
+
 # 2020.12.23
 
 ## Version bumps

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![codecov](https://codecov.io/gh/writememe/motherstarter/branch/develop/graph/badge.svg?token=YMRIJT034F)](https://codecov.io/gh/writememe/motherstarter)
 ![motherstarter](https://github.com/writememe/motherstarter/workflows/motherstarter/badge.svg)
 [![PyPI version](https://badge.fury.io/py/motherstarter.svg)](https://badge.fury.io/py/motherstarter)
-[![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)](https://www.python.org/downloads/release/python-360/)
 [![Python 3.7](https://img.shields.io/badge/python-3.7-blue.svg)](https://www.python.org/downloads/release/python-370/)
 [![Python 3.8](https://img.shields.io/badge/python-3.8-blue.svg)](https://www.python.org/downloads/release/python-380/)
 [![Python 3.9](https://img.shields.io/badge/python-3.9-blue.svg)](https://www.python.org/downloads/release/python-390/)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+---
+# Codecov.io configuration file for
+# https://codecov.io/gh/writememe/motherstarter
+ignore:
+  - "noxfile.py"  # Ignore nox test config file
+  - "setup.py"  # Ignore motherstarter setup file

--- a/motherstarter/__init__.py
+++ b/motherstarter/__init__.py
@@ -1,3 +1,3 @@
 # Version and author for project
-__version__ = "2020.12.23"
+__version__ = "2021.01.16"
 __author__ = "Daniel Teycheney"

--- a/motherstarter/__init__.py
+++ b/motherstarter/__init__.py
@@ -1,3 +1,3 @@
-# Specify version and author
+# Version and author for project
 __version__ = "2020.12.23"
 __author__ = "Daniel Teycheney"

--- a/motherstarter/__init__.py
+++ b/motherstarter/__init__.py
@@ -1,3 +1,3 @@
 # Specify version and author
-__version__ = "2020.11.16"
+__version__ = "2020.12.23"
 __author__ = "Daniel Teycheney"

--- a/motherstarter/motherstarter.py
+++ b/motherstarter/motherstarter.py
@@ -17,6 +17,7 @@ from motherstarter import __version__
 import os
 import sys
 
+
 # Get path of the current dir under which the file is executed
 dirname = os.path.dirname(os.path.abspath(__file__))
 # Append sys path so that relative pathing works for input
@@ -330,7 +331,9 @@ def init_inventory_xlsx(source_dir: Optional[str] = "motherstarter/inputs"):
         N/A
     """
     # Read in source file. NOTE: The source filename and sheet name are hardcoded
-    df = pd.read_excel(f"{source_dir}/inventory.xlsx", sheet_name="inventory")
+    df = pd.read_excel(
+        f"{source_dir}/inventory.xlsx", sheet_name="inventory", engine="openpyxl"
+    )
     # Return dataframe
     return df
 
@@ -397,7 +400,9 @@ def init_groups_xlsx(source_dir: Optional[str] = "motherstarter/inputs"):
         N/A
     """
     # Read in source file. NOTE: The source filename and sheet name are hardcoded
-    df = pd.read_excel(f"{source_dir}/groups.xlsx", sheet_name="groups")
+    df = pd.read_excel(
+        f"{source_dir}/groups.xlsx", sheet_name="groups", engine="openpyxl"
+    )
     # Return dataframe
     return df
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,7 +5,7 @@ motherstarter noxfile
 import nox
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9"])
+@nox.session(python=["3.7", "3.8", "3.9"])
 def lint(session):
     """
     Run all linting tests.
@@ -39,7 +39,7 @@ def lint(session):
     )
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9"])
+@nox.session(python=["3.7", "3.8", "3.9"])
 def black(session):
     """
     Nox run black
@@ -58,7 +58,7 @@ def black(session):
     session.run("black", ".", "--check")
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9"])
+@nox.session(python=["3.7", "3.8", "3.9"])
 def pylama(session):
     """
     Nox run pylama
@@ -77,7 +77,7 @@ def pylama(session):
     session.run("pylama", ".")
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9"])
+@nox.session(python=["3.7", "3.8", "3.9"])
 def yamllint(session):
     """
     Nox run yamllint
@@ -96,7 +96,7 @@ def yamllint(session):
     session.run("yamllint", ".")
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9"])
+@nox.session(python=["3.7", "3.8", "3.9"])
 def bandit(session):
     """
     Nox run bandit
@@ -127,7 +127,7 @@ def bandit(session):
     )
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9"])
+@nox.session(python=["3.7", "3.8", "3.9"])
 def tests(session):
     """
     Nox run tests using pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ jinja2==2.11.2
 mypy==0.790
 nox==2020.12.31
 openpyxl==3.0.5
-pandas==1.1.5
+pandas==1.2.0
 pylama==7.7.1
 pytest==6.2.1
 pytest-cov==2.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ click>=7.1,<=7.2
 colorama==0.4.4
 jinja2==2.11.2
 mypy==0.790
-nox==2020.8.22
+nox==2020.12.31
 openpyxl==3.0.5
 pandas==1.1.5
 pylama==7.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,9 @@ jinja2==2.11.2
 mypy==0.790
 nox==2020.8.22
 openpyxl==3.0.5
-pandas==1.1.4
+pandas==1.1.5
 pylama==7.7.1
 pytest==6.2.1
 pytest-cov==2.10.1
-xlrd==1.2.0
+xlrd==2.0.1
 yamllint==1.25.0

--- a/setup.py
+++ b/setup.py
@@ -29,14 +29,13 @@ setup(
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     include_package_data=True,
     install_requires=requirements,
     entry_points="""


### PR DESCRIPTION
## BREAKING CHANGES - Python 3.6 Support Depcrecated

- Due to an inherit [`pandas` dependency, python 3.6 support has been deprecated](https://pandas.pydata.org/pandas-docs/stable/whatsnew/v1.2.0.html#increased-minimum-version-for-python).

## Version bumps

- pandas 1.1.5 to 1.2.0
- nox 2020.8.22 to 2020.12.31

## Test Coverage Optimisations

- Ignore `codecov` analysis on motherstarter `setup.py` and `noxfile.py` files